### PR TITLE
Update phish_windows_credentials.rb

### DIFF
--- a/modules/post/windows/gather/phish_windows_credentials.rb
+++ b/modules/post/windows/gather/phish_windows_credentials.rb
@@ -50,7 +50,7 @@ class Metasploit3 < Msf::Post
     else
        sdescription = description.gsub("{PROCESS_NAME}", process)
        psh_script2 = base_script.gsub("R{DESCRIPTION}", "#{sdescription}") << "Invoke-LoginPrompt"
-       psh_script = psh_script2.gsub("R{START_PROCESS}", "start-process \"#{path}\"")
+       psh_script = psh_script2.gsub("#R{START_PROCESS}", "start-process \"#{path}\"")
     end
     compressed_script = compress_script(psh_script)
     cmd_out, runnings_pids, open_channels = execute_script(compressed_script, datastore['TIMEOUT'])


### PR DESCRIPTION
When running the Powershell phishing credential module on windows 8.1 without specifying a process, you get the XML below outputted. Sometimes, the XML takes over and you are unable to see the credentials. 


This is because when you don't specify a process, it leaves "R{START_PROCESS}" in Invoke-LoginPrompt.ps1. I verified that this causes the unwanted output by commenting it out and running the module.

To fix this, you need to add a "#" in front of R{START_PROCESS} in the Invoke-LoginPrompt.ps1. Since that now has a "#' in front, you need to update phish_windows_credentials.rb to include the "#" in front of R{START_PROCESS} in the search string on line 53. 